### PR TITLE
redirect to release

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,10 +2,10 @@
 <html>
 
 <head>
-    <title>Redirecting to main branch</title>
+    <title>Redirecting to release branch</title>
     <meta charset="utf-8">
-    <meta http-equiv="refresh" content="0; url=./main/index.html">
-    <link rel="canonical" href="https://key4hep.github.io/eede/main/">
+    <meta http-equiv="refresh" content="0; url=./release/index.html">
+    <link rel="canonical" href="https://key4hep.github.io/eede/release/">
 </head>
 
 </html>


### PR DESCRIPTION
BEGINRELEASENOTES
- As requested on #50, now https://key4hep.github.io/eede will redirect to https://key4hep.github.io/eede/release/.

ENDRELEASENOTES
