### PR TITLE
Add object name on top of objects

### DIFF
--- a/js/lib/graphic-primitives.js
+++ b/js/lib/graphic-primitives.js
@@ -108,13 +108,26 @@ export function drawStraightLink(ctx, link) {
   ctx.restore();
 }
 
-export function drawObjectHeader(ctx, object, y) {
+export function drawObjectHeader(ctx, object) {
   ctx.save();
-  ctx.font = "16px sans-serif";
-  ctx.fontWeight = "bold";
+  ctx.font = "bold 16px sans-serif";
   const text = object.constructor.name;
   const boxCenterX = object.x + object.width / 2;
+  const textWidth = ctx.measureText(text).width;
   const x = boxCenterX - ctx.measureText(text).width / 2;
-  ctx.fillText(text, x, y);
+  const topY = object.y + 20;
+
+  if (textWidth > object.width) {
+    const lines = text.split(/(?=[A-Z])/);
+    for (const [i, lineText] of lines.entries()) {
+      ctx.fillText(
+        lineText,
+        boxCenterX - ctx.measureText(lineText).width / 2,
+        topY + i * 20
+      );
+    }
+  } else {
+    ctx.fillText(text, x, topY);
+  }
   ctx.restore();
 }

--- a/js/lib/graphic-primitives.js
+++ b/js/lib/graphic-primitives.js
@@ -107,3 +107,14 @@ export function drawStraightLink(ctx, link) {
   ctx.stroke();
   ctx.restore();
 }
+
+export function drawObjectHeader(ctx, object, y) {
+  ctx.save();
+  ctx.font = "16px sans-serif";
+  ctx.fontWeight = "bold";
+  const text = object.constructor.name;
+  const boxCenterX = object.x + object.width / 2;
+  const x = boxCenterX - ctx.measureText(text).width / 2;
+  ctx.fillText(text, x, y);
+  ctx.restore();
+}

--- a/js/types/objects.js
+++ b/js/types/objects.js
@@ -2,10 +2,13 @@ import {
   drawTex,
   drawRoundedRect,
   drawTextLines,
+  drawObjectHeader,
 } from "../lib/graphic-primitives.js";
 import { getName } from "../lib/getName.js";
 import { linkTypes } from "./links.js";
 import { parseCharge } from "../lib/parseCharge.js";
+
+const TOP_MARGIN = 40;
 
 class EDMObject {
   constructor() {
@@ -14,13 +17,24 @@ class EDMObject {
     this.index = NaN;
     this.collectionId = NaN;
     this.width = 120;
-    this.height = 240;
+    this.height = 260;
     this.lineColor = "black";
     this.lineWidth = 2;
     this.color = "white";
   }
 
-  draw(ctx) {}
+  draw(ctx) {
+    drawRoundedRect(
+      ctx,
+      this.x,
+      this.y,
+      this.width,
+      this.height,
+      this.color,
+      this.radius
+    );
+    drawObjectHeader(ctx, this);
+  }
 
   isHere(mouseX, mouseY) {
     return (
@@ -46,6 +60,8 @@ export class MCParticle extends EDMObject {
     super();
     this.row = -1;
     this.texImg = null;
+    this.color = "#dff6ff";
+    this.radius = 15;
   }
 
   updateTexImg(text) {
@@ -63,15 +79,7 @@ export class MCParticle extends EDMObject {
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#dff6ff",
-      15
-    );
+    super.draw(ctx);
 
     if (this.texImg.complete) {
       drawTex(
@@ -93,7 +101,7 @@ export class MCParticle extends EDMObject {
       };
     }
 
-    const topY = this.y + 20;
+    const topY = this.y + TOP_MARGIN;
     const topLines = [];
     topLines.push("ID: " + this.index);
     topLines.push("Gen. stat.: " + this.generatorStatus);
@@ -198,23 +206,17 @@ class ReconstructedParticle extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 180;
+    this.height = 190;
+    this.color = "#fbffdf";
+    this.radius = 30;
   }
 
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#fbffdf",
-      30
-    );
+    super.draw(ctx);
 
-    const topY = this.y + 20;
+    const topY = this.y + 1.5 * TOP_MARGIN;
     const lines = [];
 
     lines.push("ID: " + this.index);
@@ -243,23 +245,17 @@ class Cluster extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 180;
+    this.height = 170;
+    this.color = "#ffe8df";
+    this.radius = 20;
   }
 
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#ffe8df",
-      20
-    );
+    super.draw(ctx);
 
-    const topY = this.y + 20;
+    const topY = this.y + TOP_MARGIN;
     const lines = [];
     lines.push("ID: " + this.index);
     lines.push("type: " + this.type);
@@ -282,23 +278,17 @@ class Track extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 180;
+    this.height = 150;
+    this.color = "#fff6df";
+    this.radius = 25;
   }
 
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#fff6df",
-      25
-    );
+    super.draw(ctx);
 
-    const topY = this.y + 20;
+    const topY = this.y + TOP_MARGIN;
 
     const lines = [];
     lines.push("ID: " + this.index);
@@ -322,23 +312,17 @@ class ParticleID extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 120;
+    this.height = 140;
+    this.color = "#c9edf7";
+    this.radius = 25;
   }
 
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#c9edf7",
-      25
-    );
+    super.draw(ctx);
 
-    const topY = this.y + 20;
+    const topY = this.y + TOP_MARGIN;
 
     const lines = [];
     lines.push("ID: " + this.index);
@@ -357,23 +341,17 @@ class Vertex extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 140;
+    this.height = 150;
+    this.color = "#f5d3ef";
+    this.radius = 25;
   }
 
   draw(ctx) {
     const boxCenterX = this.x + this.width / 2;
 
-    drawRoundedRect(
-      ctx,
-      this.x,
-      this.y,
-      this.width,
-      this.height,
-      "#f5d3ef",
-      25
-    );
+    super.draw(ctx);
 
-    const topY = this.y + 20;
+    const topY = this.y + TOP_MARGIN;
 
     const lines = [];
     lines.push("ID: " + this.index);

--- a/js/types/objects.js
+++ b/js/types/objects.js
@@ -44,9 +44,7 @@ class EDMObject {
 export class MCParticle extends EDMObject {
   constructor() {
     super();
-
     this.row = -1;
-
     this.texImg = null;
   }
 


### PR DESCRIPTION
BEGINRELEASENOTES
- As requested by @kjvbrt [here](https://github.com/key4hep/eede/pull/55#issuecomment-2225361396), now objects will draw their name at the top. 
- This will allow users to not get lost when exploring views with multiple datatypes. This way, they can know which object is which datatype according to this new title + color.

ENDRELEASENOTES
