### PR TITLE
Remove duplicate objects when drawing

### DIFF
--- a/js/filters/pre-filter.js
+++ b/js/filters/pre-filter.js
@@ -11,14 +11,30 @@ export function preFilterAssociation(
 
   const association = currentObjects.associations[associationName];
 
-  const fromCollection = association.map((association) => association.from);
+  const added = new Set();
+  const fromCollection = [];
+  const toCollection = [];
 
-  const toCollection = association.map((association) => association.to);
+  association.forEach((relation) => {
+    const from = relation.from;
+    const fromId = `${from.index}-${from.collectionId}`;
+
+    if (!added.has(fromId)) {
+      added.add(fromId);
+      fromCollection.push(from);
+    }
+
+    const to = relation.to;
+    const toId = `${to.index}-${to.collectionId}`;
+
+    if (!added.has(toId)) {
+      added.add(toId);
+      toCollection.push(to);
+    }
+  });
 
   viewObjects.datatypes[fromCollectionName].collection = fromCollection;
-
   viewObjects.datatypes[toCollectionName].collection = toCollection;
-
   viewObjects.associations[associationName] = association;
 }
 
@@ -58,7 +74,18 @@ export function preFilterOneWay(
     currentObjects.datatypes[fromCollectionName].oneToOne[relationName];
 
   const fromCollection = relations.map((relation) => relation.from);
-  const toCollection = relations.map((relation) => relation.to);
+
+  const added = new Set();
+  const toCollection = [];
+  relations.forEach((relation) => {
+    const to = relation.to;
+    const toId = `${to.index}-${to.collectionId}`;
+
+    if (!added.has(toId)) {
+      added.add(toId);
+      toCollection.push(to);
+    }
+  });
 
   viewObjects.datatypes[fromCollectionName].oneToOne[relationName] = relations;
   viewObjects.datatypes[fromCollectionName].collection = fromCollection;

--- a/js/views/templates/recoclustertrack.js
+++ b/js/views/templates/recoclustertrack.js
@@ -135,17 +135,24 @@ export function preFilterRecoClusterTrackVertex(currentObjects, viewObjects) {
 
   const fromCollection = fromDatatype.collection;
 
+  const added = new Set();
+
   const recoParticles = [];
   const clusters = [];
   const tracks = [];
   const vertexCollection = [];
 
   fromCollection.forEach((particle) => {
+    const id = `${particle.index}-${particle.collectionId}`;
+
     const clusterRelations = particle.oneToManyRelations["clusters"];
     const trackRelations = particle.oneToManyRelations["tracks"];
     const vertexRelation = particle.oneToOneRelations["startVertex"];
 
-    const total = clusterRelations.length + trackRelations.length;
+    const total =
+      clusterRelations.length +
+      trackRelations.length +
+      (vertexRelation !== undefined ? 1 : 0);
 
     if (total === 0) {
       return;
@@ -153,20 +160,38 @@ export function preFilterRecoClusterTrackVertex(currentObjects, viewObjects) {
 
     clusterRelations.forEach((clusterRelation) => {
       const cluster = clusterRelation.to;
-      clusters.push(cluster);
+      const clusterId = `${cluster.index}-${cluster.collectionId}`;
+
+      if (!added.has(clusterId)) {
+        added.add(clusterId);
+        clusters.push(cluster);
+      }
     });
 
     trackRelations.forEach((trackRelation) => {
       const track = trackRelation.to;
-      tracks.push(track);
+      const trackId = `${track.index}-${track.collectionId}`;
+
+      if (!added.has(trackId)) {
+        added.add(trackId);
+        tracks.push(track);
+      }
     });
 
     if (vertexRelation !== undefined) {
       const vertex = vertexRelation.to;
-      vertexCollection.push(vertex);
+      const vertexId = `${vertex.index}-${vertex.collectionId}`;
+
+      if (!added.has(vertexId)) {
+        added.add(vertexId);
+        vertexCollection.push(vertex);
+      }
     }
 
-    recoParticles.push(particle);
+    if (!added.has(id)) {
+      added.add(id);
+      recoParticles.push(particle);
+    }
   });
 
   viewObjects.datatypes["edm4hep::ReconstructedParticle"].collection =


### PR DESCRIPTION
BEGINRELEASENOTES
- There is a problem in #74, where an object was drawn twice in the `Reco-Cluster-Track-Vertex` view. The root cause was the pre-filtering functions for each view. These functions were assuming some "cardinality" for relations. What I mean is that one reco particle may have many clusters, and _assumed_ that one cluster belongs to only _one_ reco, which was wrong. 
- To fix this, I've used some sets to ensure no object is added twice. This bug was present not only in that view but also in those views that are relations (that recently changed the name to link, like MCRecoLink). So I've also added validations for those views.

ENDRELEASENOTES
