### PR TITLE
Fix particleid reco filtering

### DIFF
--- a/css/filter.css
+++ b/css/filter.css
@@ -4,7 +4,7 @@
   top: 10px;
   right: 10px;
   z-index: 1;
-  width: 300px;
+  width: 320px;
   max-height: 65vh;
   padding: 10px;
   background-color: #e1e1e1;

--- a/js/draw/box.js
+++ b/js/draw/box.js
@@ -33,7 +33,7 @@ function createText(
 
 function createObjectModal(lines) {
   const text = createText(lines.join("\n"), {
-    fontFamily: "sans-serif",
+    fontFamily: ["Arial", "sans-serif"],
     fontSize: 14,
     fontWeight: "normal",
     align: "center",

--- a/js/filters/collections/particleid.js
+++ b/js/filters/collections/particleid.js
@@ -38,6 +38,7 @@ function renderParticleIdFilters(viewObjects) {
     const checkbox = new CheckboxComponent("type", type, type, true);
     checkboxes.type.push(checkbox);
     typeCheckboxesContainer.appendChild(checkbox.render());
+    checkbox.checked(true);
   });
   typeContainer.appendChild(typeCheckboxesContainer);
 
@@ -53,6 +54,7 @@ function renderParticleIdFilters(viewObjects) {
     const checkbox = new CheckboxComponent("PDG", pdg, pdg, true);
     checkboxes.pdg.push(checkbox);
     pdgCheckboxesContainer.appendChild(checkbox.render());
+    checkbox.checked(true);
   });
   pdgContainer.appendChild(pdgCheckboxesContainer);
 
@@ -73,6 +75,7 @@ function renderParticleIdFilters(viewObjects) {
     );
     checkboxes.algorithmType.push(checkbox);
     algorithmTypeCheckboxesContainer.appendChild(checkbox.render());
+    checkbox.checked(true);
   });
   algorithmTypeContainer.appendChild(algorithmTypeCheckboxesContainer);
 

--- a/js/filters/filter.js
+++ b/js/filters/filter.js
@@ -150,7 +150,7 @@ export function initFilters(
       return;
     }
 
-    reconnectFunction(viewCurrentObjects, ids);
+    reconnectFunction(viewCurrentObjects, ids, collections);
     await render(viewCurrentObjects);
     const { x, y } = filterScroll();
     setScroll(x, y);
@@ -158,7 +158,7 @@ export function initFilters(
     setRenderable(viewCurrentObjects);
   };
   filters.reset = async () => {
-    restoreRelations(viewCurrentObjects);
+    restoreRelations(viewObjects);
     resetFiltersContent();
     copyObject(viewObjects, viewCurrentObjects);
     await render(viewCurrentObjects);

--- a/js/lib/extract-relations.js
+++ b/js/lib/extract-relations.js
@@ -1,0 +1,28 @@
+import { datatypes } from "../../output/datatypes.js";
+
+export function getRelationsFromCollections(collections) {
+  const collectionsSet = new Set(collections);
+  const relationsFromCollection = new Set();
+
+  collections.forEach((collection) => {
+    const { oneToOneRelations, oneToManyRelations } = datatypes[collection];
+
+    if (oneToManyRelations) {
+      oneToManyRelations.forEach(({ type, name }) => {
+        if (collectionsSet.has(type) && type !== collection) {
+          relationsFromCollection.add(name);
+        }
+      });
+    }
+
+    if (oneToOneRelations) {
+      oneToOneRelations.forEach(({ type, name }) => {
+        if (collectionsSet.has(type) && type !== collection) {
+          relationsFromCollection.add(name);
+        }
+      });
+    }
+  });
+
+  return relationsFromCollection;
+}

--- a/js/types/objects.js
+++ b/js/types/objects.js
@@ -224,8 +224,8 @@ export class MCParticle extends EDMObject {
 class ReconstructedParticle extends EDMObject {
   constructor() {
     super();
-    this.width = 145;
-    this.height = 190;
+    this.width = 170;
+    this.height = 200;
     this.color = "#fbffdf";
     this.radius = 30;
     this.titleName = "Reconstructed\nParticle";
@@ -256,8 +256,8 @@ class ReconstructedParticle extends EDMObject {
 class Cluster extends EDMObject {
   constructor() {
     super();
-    this.width = 140;
-    this.height = 170;
+    this.width = 145;
+    this.height = 200;
     this.color = "#ffe8df";
     this.radius = 20;
     this.titleName = "Cluster";
@@ -288,7 +288,7 @@ class Track extends EDMObject {
   constructor() {
     super();
     this.width = 140;
-    this.height = 150;
+    this.height = 180;
     this.color = "#fff6df";
     this.radius = 25;
     this.titleName = "Track";
@@ -348,8 +348,8 @@ class ParticleID extends EDMObject {
 class Vertex extends EDMObject {
   constructor() {
     super();
-    this.width = 140;
-    this.height = 150;
+    this.width = 155;
+    this.height = 175;
     this.color = "#f5d3ef";
     this.radius = 25;
     this.titleName = "Vertex";

--- a/js/views/templates/tree.js
+++ b/js/views/templates/tree.js
@@ -98,7 +98,7 @@ export function buildTree(collection, relationOfReference) {
 
   matrix.forEach((row, i) => {
     row.forEach((object, j) => {
-      const row = i + startingRow - 1;
+      const row = i + startingRow;
       const col = j;
       object.x = col * horizontalGap + col * boxWidth + horizontalGap;
       object.y = row * verticalGap + row * boxHeight + verticalGap;


### PR DESCRIPTION
BEGINRELEASENOTES
- Fix bug #75. It was filtering all relations of the same object, instead of doing according to the relations used in that view.
- I've also made boxes a bit larger (so text doesn't overflow, test on firefox). 

ENDRELEASENOTES
