### PR TITLE
Using fetch to get the JSON with the supported EDM4hep objects

### DIFF
--- a/js/globals.js
+++ b/js/globals.js
@@ -24,7 +24,12 @@ export function isPixiRunning() {
 /*
  * Datatypes
  */
-import supportedEDM4hepTypes from '../model/datatypes.json' with { type: 'json' };
+// Oct 2025:
+// Simple import is not yet fully supported by all the browsers in the wild.
+// Notable mention: Firefox on AlmaLinux 9.
+// import supportedEDM4hepTypes from '../model/datatypes.json' with { type: 'json' };
+const supportedEDM4hepTypes = await fetch('../model/datatypes.json')
+  .then(res => res.json());
 
 export function getSupportedEDM4hepTypes(schemaVersion) {
   if (typeof schemaVersion === 'undefined') {


### PR DESCRIPTION
BEGINRELEASENOTES
- Using fetch to get the JSON with the supported EDM4hep objects, import is not yet supported in all the browsers in the wild

ENDRELEASENOTES
